### PR TITLE
TR-0106: Fix macOS local build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,22 @@ TEST_FILES := test_report_loader test_xml_generator test_application_service tes
 
 # Detect environment: skip docker exec if already inside the container
 INSIDE_DOCKER := $(shell if [ -f /.dockerenv ]; then echo "yes"; else echo "no"; fi)
+# macOS: use host.docker.internal for X11 (XQuartz); Linux: use DISPLAY
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    DOCKER_DISPLAY := host.docker.internal:0
+else
+    DOCKER_DISPLAY := $(or $(DISPLAY),:0)
+endif
+# Env for build/configure: ccache dir + offscreen so test discovery and ctest don't need a display
+DOCKER_BUILD_ENV := -e CCACHE_DIR=/app/build/.ccache -e QT_QPA_PLATFORM=offscreen
 
 ifeq ($(INSIDE_DOCKER),yes)
-    CMD_PREFIX := 
+    CMD_PREFIX :=
+    BUILD_CMD_PREFIX :=
 else
     CMD_PREFIX := docker exec $(CONTAINER_NAME)
+    BUILD_CMD_PREFIX := docker exec $(DOCKER_BUILD_ENV) $(CONTAINER_NAME)
 endif
 
 # ---------------------------
@@ -33,10 +44,10 @@ dev-up:
 	else \
 		docker run -d --name $(CONTAINER_NAME) \
 			-v "$(PWD)":/app -v $(CACHE_VOLUME):/app/$(BUILD_DIR) \
-			-e DISPLAY=$(DISPLAY) -v /tmp/.X11-unix:/tmp/.X11-unix \
+			-e DISPLAY=$(DOCKER_DISPLAY) -v /tmp/.X11-unix:/tmp/.X11-unix \
 			--user $(shell id -u):$(shell id -g) $(IMAGE_NAME) sleep infinity; \
 	fi
-	@xhost +local:docker > /dev/null
+	@[ "$(UNAME_S)" = "Darwin" ] || (command -v xhost >/dev/null 2>&1 && xhost +local:docker >/dev/null) || true
 	@echo "Development engine is READY."
 
 dev-down:
@@ -50,28 +61,29 @@ dev-down:
 # ---------------------------
 
 configure:
-	$(CMD_PREFIX) cmake -G Ninja -S . -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=Debug
+	$(BUILD_CMD_PREFIX) cmake -G Ninja -S . -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=Debug
 
 build-test-report-loader:
-	$(CMD_PREFIX) cmake --build $(BUILD_DIR) --target test_report_loader -j$(shell nproc)
+	$(BUILD_CMD_PREFIX) cmake --build $(BUILD_DIR) --target test_report_loader -j$(shell nproc)
 
 build-test-xml-generator:
-	$(CMD_PREFIX) cmake --build $(BUILD_DIR) --target test_xml_generator -j$(shell nproc)
+	$(BUILD_CMD_PREFIX) cmake --build $(BUILD_DIR) --target test_xml_generator -j$(shell nproc)
 
 build-test-application-service:
-	$(CMD_PREFIX) cmake --build $(BUILD_DIR) --target test_application_service -j$(shell nproc)
+	$(BUILD_CMD_PREFIX) cmake --build $(BUILD_DIR) --target test_application_service -j$(shell nproc)
 
 build-test-gui:
-	$(CMD_PREFIX) cmake --build $(BUILD_DIR) --target test_gui -j$(shell nproc)
+	$(BUILD_CMD_PREFIX) cmake --build $(BUILD_DIR) --target test_gui -j$(shell nproc)
 
 # Build only the main application binary
 build-main:
-	$(CMD_PREFIX) cmake --build $(BUILD_DIR) --target EdavkiXmlMaker -j$(shell nproc)
+	$(BUILD_CMD_PREFIX) cmake --build $(BUILD_DIR) --target EdavkiXmlMaker -j$(shell nproc)
 
 build:
-	$(CMD_PREFIX) cmake --build $(BUILD_DIR) -j$(shell nproc)
+	$(BUILD_CMD_PREFIX) cmake --build $(BUILD_DIR) -j$(shell nproc)
 
 run: build
+	@[ "$(UNAME_S)" = "Darwin" ] && echo "Tip: If the GUI does not open, run XQuartz, enable Preferences → Security → 'Allow connections from network clients', restart XQuartz, then run: xhost +localhost" || true
 	$(CMD_PREFIX) ./$(BUILD_DIR)/EdavkiXmlMaker
 
 test: build
@@ -81,16 +93,16 @@ coverage: build
 	@echo "Generating code coverage report..."
 	# 1. Reset counters
 	$(CMD_PREFIX) lcov --directory build --zerocounters
-	
+
 	# 2. Run all tests (ignore SegFault with '-')
 	-$(CMD_PREFIX) bash -c "QT_QPA_PLATFORM=offscreen ctest --test-dir build"
-	
+
 	# 3. Capture coverage data
 	$(CMD_PREFIX) lcov --directory build --capture --output-file build/coverage.info
-	
+
 	# 4. FILTER: Keep only src subfolders and the root util folder
 	$(CMD_PREFIX) lcov --extract build/coverage.info "*/src/api/*" "*/src/backend/*" "*/src/gui/*" "*/src/util/*" --output-file build/coverage_filtered.info
-	
+
 	# 5. Generate HTML report and strip path prefixes for a clean view
 	# Using --prefix /app/src and --prefix /app ensures all folders look like top-level names
 	$(CMD_PREFIX) genhtml build/coverage_filtered.info \
@@ -100,7 +112,7 @@ coverage: build
 	@echo "Report generated at tests/coverage_report/index.html"
 
 clean:
-	$(CMD_PREFIX) rm -rf $(BUILD_DIR)/*
+	$(BUILD_CMD_PREFIX) rm -rf $(BUILD_DIR)/*
 
 # Hard clean
 # Use this when clean does not work
@@ -120,10 +132,10 @@ release-linux:
 	@echo "Manufacturing Linux Standalone (v$(VERSION))..."
 	@mkdir -p $(LINUX_VERSION_DIR)
 	@chmod +x production/linux/bundle.sh
-	
+
 	# Build the tool environment
 	docker build --target bundler -t edavki-bundler .
-	
+
 	# Run the factory: Build THEN Bundle
 	docker run --rm \
 		-v "$(CURDIR)/$(LINUX_VERSION_DIR)":/export \

--- a/docs/developers/build-instructions.md
+++ b/docs/developers/build-instructions.md
@@ -34,10 +34,42 @@ make build
 make run
 ```
 
+## 🍎 Running the GUI on macOS (Docker + XQuartz)
+
+The app runs in a Linux container and draws to your Mac via X11. You need **XQuartz** and one-time setup:
+
+1. **Install XQuartz** (if needed):
+   `brew install --cask xquartz`
+   Then **log out and back in** (or reboot) so the X11 app is properly registered.
+
+2. **Allow network clients** (required for Docker to connect):
+   - Open **XQuartz** (Applications → Utilities → XQuartz).
+   - In the menu bar: **XQuartz → Preferences → Security**.
+   - Check **"Allow connections from network clients"**.
+   - **Quit XQuartz completely** (XQuartz → Quit) and open it again.
+
+3. **Allow localhost** (in Terminal, each time after you start XQuartz):
+   ```bash
+   xhost +localhost
+   ```
+
+4. **Start the dev container** (so it gets `DISPLAY=host.docker.internal:0`):
+   ```bash
+   make dev-down
+   make dev-up
+   ```
+
+5. **Build and run**:
+   ```bash
+   make run
+   ```
+
+The app window should appear in XQuartz. If you see `could not connect to display host.docker.internal:0`, re-check steps 2 and 3 and ensure XQuartz is running.
+
 ## 🧪 Testing & Quality
 
 - Run Unit Tests: Executes all GoogleTest suites (headless).
-  
+
   ```Bash
   make test
   ```
@@ -52,7 +84,7 @@ make run
   ```
 
 - Code Coverage: Generates an HTML report of test coverage.
-  
+
   ```Bash
   make coverage
   # Open tests/coverage_report/index.html to view
@@ -76,8 +108,8 @@ make run
 
 ## 🧹 Cleanup
 
-- Stop for the day: 
-  
+- Stop for the day:
+
   ```Bash
   make dev-down
   ```
@@ -91,7 +123,7 @@ make run
   ```
 
 - Nuclear Reset: clean (Wipes build cache) or manually remove the edavki-dev-cache volume to start fresh.
-  
+
   ```Bash
   make clean-rebuild
   ```


### PR DESCRIPTION
- Updated Makefile to improve Docker handling for macOS, including X11 display configuration.
- Added detailed instructions for running the GUI on macOS with XQuartz in the build documentation.

# Pull Request solving Issue: None

## Description
Please describe the purpose of this PR and link the issue (e.g., Fixes #123).  

## Checklist
- [ ] Issue linked
- [ ] Code compiles / tests pass
- [ ] README / doc / instructions updated if needed
